### PR TITLE
Add dashboard and navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# plantilla-ejercicios
+# Plantilla de Ejercicios
+
+Este repositorio contiene diversas guías en formato HTML para practicar JavaScript y el desarrollo full‑stack. Abre `dashboard.html` en tu navegador para elegir rápidamente el taller que quieras seguir.
+
+## Contenido
+
+- **Fundamentos de JavaScript** – `ejercicios-basicos-javascript.html`
+- **Backend Node.js + React TypeScript** – `index.html`
+- **Taller Full-Stack CRUD Avanzado** – `fullstack-react-nodejs-typescript.html`
+
+Cada archivo puede abrirse directamente en el navegador sin necesidad de un servidor adicional.

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>📚 Dashboard de Ejercicios</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #2c3e50; min-height: 100vh; display: flex; align-items: center; justify-content: center; }
+    main { background: white; padding: 2rem; border-radius: 16px; box-shadow: 0 10px 30px rgba(0,0,0,0.1); }
+    h1 { text-align: center; margin-bottom: 1.5rem; }
+    ul { list-style: none; display: flex; flex-direction: column; gap: 1rem; }
+    a { display: block; padding: 1rem; background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); color: white; text-decoration: none; border-radius: 8px; font-weight: 600; text-align: center; }
+    a:hover { opacity: 0.9; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>📚 Selecciona un Ejercicio</h1>
+    <ul>
+      <li><a href="ejercicios-basicos-javascript.html">Fundamentos de JavaScript</a></li>
+      <li><a href="index.html">Backend Node.js + React TypeScript</a></li>
+      <li><a href="fullstack-react-nodejs-typescript.html">Taller Full-Stack CRUD Avanzado</a></li>
+    </ul>
+  </main>
+</body>
+</html>

--- a/ejercicios-basicos-javascript.html
+++ b/ejercicios-basicos-javascript.html
@@ -387,9 +387,22 @@
       50% { opacity: 0.7; }
       100% { opacity: 1; }
     }
+      .nav-dashboard {
+        text-align: center;
+        background: rgba(0,0,0,0.1);
+        padding: 0.5rem 0;
+      }
+      .nav-dashboard a {
+        color: white;
+        text-decoration: none;
+        font-weight: bold;
+      }
   </style>
 </head>
 <body>
+  <nav class="nav-dashboard">
+    <a href="dashboard.html">🏠 Ir al Dashboard</a>
+  </nav>
   <header>
     <div class="container">
       <div class="header-content">

--- a/fullstack-react-nodejs-typescript.html
+++ b/fullstack-react-nodejs-typescript.html
@@ -52,9 +52,22 @@
     @media (max-width: 768px) { h1 { font-size: 2.5rem; } .section { padding: 2rem; margin-bottom: 2rem; } .feature-grid { grid-template-columns: 1fr; } .tech-badges { gap: 1rem; } .badge { padding: 0.6rem 1rem; font-size: 0.9rem; } .section-header { flex-direction: column; text-align: center; } .section-icon { width: 50px; height: 50px; font-size: 1.5rem; } h2 { font-size: 1.8rem; } }
     .pulse { animation: pulse 2s infinite; }
     @keyframes pulse { 0% { opacity: 1; transform: scale(1); } 50% { opacity: 0.8; transform: scale(1.05); } 100% { opacity: 1; transform: scale(1); } }
+      .nav-dashboard {
+        text-align: center;
+        background: rgba(0,0,0,0.1);
+        padding: 0.5rem 0;
+      }
+      .nav-dashboard a {
+        color: white;
+        text-decoration: none;
+        font-weight: bold;
+      }
   </style>
 </head>
 <body>
+  <nav class="nav-dashboard">
+    <a href="dashboard.html">🏠 Ir al Dashboard</a>
+  </nav>
   <header>
     <div class="container">
       <div class="header-content">

--- a/index.html
+++ b/index.html
@@ -333,9 +333,22 @@
       50% { opacity: 0.7; }
       100% { opacity: 1; }
     }
+      .nav-dashboard {
+        text-align: center;
+        background: rgba(0,0,0,0.1);
+        padding: 0.5rem 0;
+      }
+      .nav-dashboard a {
+        color: white;
+        text-decoration: none;
+        font-weight: bold;
+      }
   </style>
 </head>
 <body>
+  <nav class="nav-dashboard">
+    <a href="dashboard.html">🏠 Ir al Dashboard</a>
+  </nav>
   <header>
     <div class="container">
       <div class="header-content">


### PR DESCRIPTION
## Summary
- add a simple `dashboard.html` with links to each exercise
- link all exercises back to the dashboard
- improve README with instructions
- ensure HTML files end correctly and include a small navigation style

## Testing
- `tidy -qe dashboard.html index.html ejercicios-basicos-javascript.html fullstack-react-nodejs-typescript.html`

------
https://chatgpt.com/codex/tasks/task_e_683fa72505ac8321b88497112f634835